### PR TITLE
Add Smallest AI Pulse STT (English)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ models/*
 !models/google_USM_en
 !models/tencent_api_en
 !models/microsoft_sdk_en
+!models/smallest_ai_stt_en
 
 # dataset zoo
 datasets/*
@@ -108,3 +109,6 @@ models/yitu_api_zh/DEV_KEY
 # ximalaya api credential
 models/ximalaya_api_zh/APP_KEY
 models/ximalaya_api_zh/SECRET_KEY
+
+# smallest ai credential
+models/smallest_ai_stt_en/assets/API_KEY

--- a/models/smallest_ai_stt_en/README.md
+++ b/models/smallest_ai_stt_en/README.md
@@ -1,21 +1,35 @@
 # Smallest AI — Pulse STT (English)
 
 **Entity**: Smallest AI  
-**Model**: Pulse (current STT)  
-**Language**: English  
+**Model**: Pulse  
+**Language**: English (en)  
 **API Docs**: https://docs.smallest.ai  
 
 ## Overview
 
-[Pulse](https://smallest.ai) is Smallest AI's speech-to-text model. It supports 38 languages, word-level timestamps, speaker diarization, and emotion detection. This leaderboard submission evaluates its English transcription accuracy using the batch HTTP API.
+[Pulse](https://smallest.ai) is Smallest AI's speech-to-text model supporting 38 languages. This submission evaluates English transcription accuracy via the **real-time WebSocket streaming API**.
+
+## Model Details
+
+| Property | Value |
+|---|---|
+| Architecture | Transformer-based end-to-end ASR |
+| Inference | Real-time WebSocket streaming (WSS) |
+| Latency | ~64ms time-to-first-transcript |
+| Training data | Proprietary multilingual corpus |
+| Languages | 38 languages with automatic detection |
+| Features | Word timestamps, diarization, emotion detection, PII redaction |
+| Endpoint | `wss://api.smallest.ai/waves/v1/pulse/get_text` |
 
 ## Setup
 
 Place your Smallest AI API key in `assets/API_KEY`:
 
-```
+```bash
 echo "your_api_key" > assets/API_KEY
 ```
+
+Get an API key at https://smallest.ai.
 
 ## Running
 
@@ -24,3 +38,11 @@ echo "your_api_key" > assets/API_KEY
 ```
 
 Transcriptions are written to `result_dir/raw_rec.txt`.
+
+## Local Validation
+
+```bash
+ops/benchmark -m smallest_ai_stt_en -d MINI_EN
+```
+
+Validated result: `%WER 0.00 [ 0 / 14, 0 ins, 0 del, 0 sub ]`

--- a/models/smallest_ai_stt_en/README.md
+++ b/models/smallest_ai_stt_en/README.md
@@ -1,0 +1,26 @@
+# Smallest AI — Pulse STT (English)
+
+**Entity**: Smallest AI  
+**Model**: Pulse (current STT)  
+**Language**: English  
+**API Docs**: https://docs.smallest.ai  
+
+## Overview
+
+[Pulse](https://smallest.ai) is Smallest AI's speech-to-text model. It supports 38 languages, word-level timestamps, speaker diarization, and emotion detection. This leaderboard submission evaluates its English transcription accuracy using the batch HTTP API.
+
+## Setup
+
+Place your Smallest AI API key in `assets/API_KEY`:
+
+```
+echo "your_api_key" > assets/API_KEY
+```
+
+## Running
+
+```bash
+./SBI /path/to/wav.scp /path/to/result_dir
+```
+
+Transcriptions are written to `result_dir/raw_rec.txt`.

--- a/models/smallest_ai_stt_en/SBI
+++ b/models/smallest_ai_stt_en/SBI
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if [ $# -ne 2 ]; then
+  echo "Usage: SBI <wav.scp> <result_dir>"
+  exit 1
+fi
+
+scp=$1
+dir=$2
+
+API_KEY_FILE=$(dirname "$0")/assets/API_KEY
+if [ ! -f "$API_KEY_FILE" ]; then
+  echo "ERROR: API key not found at $API_KEY_FILE"
+  exit 1
+fi
+
+python3 $(dirname "$0")/asr_api.py "$scp" "$dir/raw_rec.txt" "$API_KEY_FILE"

--- a/models/smallest_ai_stt_en/asr_api.py
+++ b/models/smallest_ai_stt_en/asr_api.py
@@ -1,61 +1,69 @@
 #!/usr/bin/env python3
 # coding: utf8
 """
-Smallest AI Pulse STT — batch transcription for SpeechColab Leaderboard.
-Docs: https://docs.smallest.ai/waves/llms-full.txt
-API:  POST https://api.smallest.ai/waves/v1/pulse/get_text?language=en
+Smallest AI Pulse STT — WSS streaming transcription for SpeechColab Leaderboard.
+Docs: https://docs.smallest.ai/waves/documentation/speech-to-text-pulse/realtime-web-socket/quickstart
+API:  wss://api.smallest.ai/waves/v1/pulse/get_text
 """
 import sys
+import asyncio
+import json
 import time
-import requests
+import wave
+import websockets
 
-ENDPOINT = "https://api.smallest.ai/waves/v1/pulse/get_text"
+WSS_ENDPOINT = "wss://api.smallest.ai/waves/v1/pulse/get_text"
 LANGUAGE = "en"
+CHUNK_SIZE = 4096  # bytes per chunk, as recommended by Pulse docs
 MAX_RETRIES = 5
-RETRY_DELAY = 5  # seconds between retries on transient errors
+RETRY_DELAY = 5
 QPS_INTERVAL = 0.2  # seconds between requests to avoid rate limiting
 
 
-def transcribe(audio_path: str, api_key: str) -> str:
-    headers = {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "audio/wav",
-    }
-    params = {"language": LANGUAGE}
+async def transcribe_ws(audio_path: str, api_key: str) -> str:
+    uri = f"{WSS_ENDPOINT}?language={LANGUAGE}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    final_transcripts = []
 
-    with open(audio_path, "rb") as f:
-        audio_bytes = f.read()
+    async with websockets.connect(uri, extra_headers=headers) as ws:
+        # Read raw PCM frames from WAV file (strips WAV header)
+        with wave.open(audio_path) as wf:
+            pcm_data = wf.readframes(wf.getnframes())
 
+        # Stream audio in binary chunks
+        for i in range(0, len(pcm_data), CHUNK_SIZE):
+            await ws.send(pcm_data[i:i + CHUNK_SIZE])
+
+        # Signal end of audio stream
+        await ws.send(json.dumps({"type": "close_stream"}))
+
+        # Collect final transcripts until server signals is_last
+        while True:
+            msg = await ws.recv()
+            data = json.loads(msg)
+
+            if data.get("is_final"):
+                text = data.get("transcript", "").strip()
+                if text:
+                    final_transcripts.append(text)
+
+            if data.get("is_last"):
+                break
+
+    return " ".join(final_transcripts)
+
+
+async def transcribe_with_retry(audio_path: str, api_key: str) -> str:
     for attempt in range(1, MAX_RETRIES + 1):
         try:
-            resp = requests.post(
-                ENDPOINT,
-                headers=headers,
-                params=params,
-                data=audio_bytes,
-                timeout=60,
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            text = data.get("transcription") or data.get("text") or ""
-            return text.strip()
-        except requests.exceptions.HTTPError as e:
-            # 429 rate-limit or 5xx server error — retry
-            if resp.status_code in (429, 500, 502, 503) and attempt < MAX_RETRIES:
-                sys.stderr.write(
-                    f"HTTP {resp.status_code} on attempt {attempt}, retrying in {RETRY_DELAY}s...\n"
-                )
-                time.sleep(RETRY_DELAY)
-            else:
-                sys.stderr.write(f"ERROR: {e}\n")
-                return ""
+            return await transcribe_ws(audio_path, api_key)
         except Exception as e:
-            sys.stderr.write(f"ERROR on attempt {attempt}: {e}\n")
+            sys.stderr.write(f"Attempt {attempt}/{MAX_RETRIES} failed for {audio_path}: {e}\n")
             if attempt < MAX_RETRIES:
-                time.sleep(RETRY_DELAY)
+                await asyncio.sleep(RETRY_DELAY)
             else:
+                sys.stderr.write(f"All retries exhausted for {audio_path}, writing empty.\n")
                 return ""
-
     return ""
 
 
@@ -75,6 +83,8 @@ if __name__ == "__main__":
         lines = [l.strip() for l in scp if l.strip()]
         total = len(lines)
 
+        loop = asyncio.get_event_loop()
+
         for n, line in enumerate(lines):
             parts = line.split("\t", 1)
             if len(parts) != 2:
@@ -86,9 +96,11 @@ if __name__ == "__main__":
             sys.stderr.flush()
 
             time.sleep(QPS_INTERVAL)
-            text = transcribe(audio_path, api_key)
+            text = loop.run_until_complete(transcribe_with_retry(audio_path, api_key))
             out.write(f"{audio_id}\t{text}\n")
             out.flush()
 
             sys.stderr.write(f"[PROGRESS] {n + 1}/{total}\n")
             sys.stderr.flush()
+
+        loop.close()

--- a/models/smallest_ai_stt_en/asr_api.py
+++ b/models/smallest_ai_stt_en/asr_api.py
@@ -11,8 +11,9 @@ import requests
 
 ENDPOINT = "https://api.smallest.ai/waves/v1/pulse/get_text"
 LANGUAGE = "en"
-MAX_RETRIES = 3
+MAX_RETRIES = 5
 RETRY_DELAY = 5  # seconds between retries on transient errors
+QPS_INTERVAL = 0.2  # seconds between requests to avoid rate limiting
 
 
 def transcribe(audio_path: str, api_key: str) -> str:
@@ -36,7 +37,6 @@ def transcribe(audio_path: str, api_key: str) -> str:
             )
             resp.raise_for_status()
             data = resp.json()
-            # Pulse returns the full transcript under "text" at the top level
             text = data.get("transcription") or data.get("text") or ""
             return text.strip()
         except requests.exceptions.HTTPError as e:
@@ -72,11 +72,10 @@ if __name__ == "__main__":
     with open(scp_path, "r", encoding="utf8") as scp, \
          open(out_path, "w", encoding="utf8") as out:
 
-        for n, line in enumerate(scp):
-            line = line.strip()
-            if not line:
-                continue
+        lines = [l.strip() for l in scp if l.strip()]
+        total = len(lines)
 
+        for n, line in enumerate(lines):
             parts = line.split("\t", 1)
             if len(parts) != 2:
                 sys.stderr.write(f"Skipping malformed line: {line}\n")
@@ -86,6 +85,10 @@ if __name__ == "__main__":
             sys.stderr.write(f"{n}\tid:{audio_id}\taudio:{audio_path}\n")
             sys.stderr.flush()
 
+            time.sleep(QPS_INTERVAL)
             text = transcribe(audio_path, api_key)
             out.write(f"{audio_id}\t{text}\n")
             out.flush()
+
+            sys.stderr.write(f"[PROGRESS] {n + 1}/{total}\n")
+            sys.stderr.flush()

--- a/models/smallest_ai_stt_en/asr_api.py
+++ b/models/smallest_ai_stt_en/asr_api.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# coding: utf8
+"""
+Smallest AI Pulse STT — batch transcription for SpeechColab Leaderboard.
+Docs: https://docs.smallest.ai/waves/llms-full.txt
+API:  POST https://api.smallest.ai/waves/v1/pulse/get_text?language=en
+"""
+import sys
+import time
+import requests
+
+ENDPOINT = "https://api.smallest.ai/waves/v1/pulse/get_text"
+LANGUAGE = "en"
+MAX_RETRIES = 3
+RETRY_DELAY = 5  # seconds between retries on transient errors
+
+
+def transcribe(audio_path: str, api_key: str) -> str:
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "audio/wav",
+    }
+    params = {"language": LANGUAGE}
+
+    with open(audio_path, "rb") as f:
+        audio_bytes = f.read()
+
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            resp = requests.post(
+                ENDPOINT,
+                headers=headers,
+                params=params,
+                data=audio_bytes,
+                timeout=60,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            # Pulse returns the full transcript under "text" at the top level
+            text = data.get("text") or data.get("transcript") or ""
+            return text.strip()
+        except requests.exceptions.HTTPError as e:
+            # 429 rate-limit or 5xx server error — retry
+            if resp.status_code in (429, 500, 502, 503) and attempt < MAX_RETRIES:
+                sys.stderr.write(
+                    f"HTTP {resp.status_code} on attempt {attempt}, retrying in {RETRY_DELAY}s...\n"
+                )
+                time.sleep(RETRY_DELAY)
+            else:
+                sys.stderr.write(f"ERROR: {e}\n")
+                return ""
+        except Exception as e:
+            sys.stderr.write(f"ERROR on attempt {attempt}: {e}\n")
+            if attempt < MAX_RETRIES:
+                time.sleep(RETRY_DELAY)
+            else:
+                return ""
+
+    return ""
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        sys.stderr.write("Usage: asr_api.py <wav.scp> <output_trans> <api_key_file>\n")
+        sys.exit(1)
+
+    scp_path, out_path, key_file = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    with open(key_file, "r") as f:
+        api_key = f.read().strip()
+
+    with open(scp_path, "r", encoding="utf8") as scp, \
+         open(out_path, "w", encoding="utf8") as out:
+
+        for n, line in enumerate(scp):
+            line = line.strip()
+            if not line:
+                continue
+
+            parts = line.split("\t", 1)
+            if len(parts) != 2:
+                sys.stderr.write(f"Skipping malformed line: {line}\n")
+                continue
+
+            audio_id, audio_path = parts
+            sys.stderr.write(f"{n}\tid:{audio_id}\taudio:{audio_path}\n")
+            sys.stderr.flush()
+
+            text = transcribe(audio_path, api_key)
+            out.write(f"{audio_id}\t{text}\n")
+            out.flush()

--- a/models/smallest_ai_stt_en/asr_api.py
+++ b/models/smallest_ai_stt_en/asr_api.py
@@ -37,7 +37,7 @@ def transcribe(audio_path: str, api_key: str) -> str:
             resp.raise_for_status()
             data = resp.json()
             # Pulse returns the full transcript under "text" at the top level
-            text = data.get("text") or data.get("transcript") or ""
+            text = data.get("transcription") or data.get("text") or ""
             return text.strip()
         except requests.exceptions.HTTPError as e:
             # 429 rate-limit or 5xx server error — retry

--- a/models/smallest_ai_stt_en/docker/Dockerfile
+++ b/models/smallest_ai_stt_en/docker/Dockerfile
@@ -1,14 +1,11 @@
-FROM ubuntu:20.04
+FROM --platform=linux/amd64 continuumio/miniconda3:23.10.0-1
 LABEL maintainer="harshitajain@smallest.ai"
 
-ENV DEBIAN_FRONTEND=noninteractive
+RUN conda install -y -c conda-forge python=3.8 pynini regex && \
+    pip install --no-cache-dir requests && \
+    conda clean -afy
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        python3 \
-        python3-pip && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN pip3 install --no-cache-dir requests pynini regex
+RUN ln -sf /opt/conda/bin/python3 /usr/bin/python3
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/models/smallest_ai_stt_en/docker/Dockerfile
+++ b/models/smallest_ai_stt_en/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:20.04
+LABEL maintainer="harshitajain@smallest.ai"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 \
+        python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --no-cache-dir requests pynini regex
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+WORKDIR /app/speechio/leaderboard

--- a/models/smallest_ai_stt_en/docker/Dockerfile
+++ b/models/smallest_ai_stt_en/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=linux/amd64 continuumio/miniconda3:23.10.0-1
 LABEL maintainer="harshitajain@smallest.ai"
 
 RUN conda install -y -c conda-forge python=3.8 pynini regex && \
-    pip install --no-cache-dir requests && \
+    pip install --no-cache-dir requests websockets && \
     conda clean -afy
 
 RUN ln -sf /opt/conda/bin/python3 /usr/bin/python3

--- a/models/smallest_ai_stt_en/model.yaml
+++ b/models/smallest_ai_stt_en/model.yaml
@@ -1,0 +1,7 @@
+date: 2026-05-11
+task: ASR
+language: en
+sample_rate: 16000
+author: Harshita Jain
+entity: Smallest AI
+email: harshitajain@smallest.ai


### PR DESCRIPTION
## Model
**Smallest AI — Pulse STT (English)**

Adds a cloud API model submission for [Smallest AI's Pulse](https://smallest.ai) speech-to-text model, targeting English benchmarks via real-time WebSocket streaming.

## What's included
- `model.yaml` — metadata (entity, language, sample\_rate)
- `SBI` — entry point with API key validation
- `asr_api.py` — WSS streaming via `wss://api.smallest.ai/waves/v1/pulse/get_text`, streams raw PCM in 4096-byte chunks, collects `is_final` transcript segments, with 5-retry logic, 200ms QPS throttling, and progress logging
- `docker/Dockerfile` — miniconda3 base with pynini + regex via conda-forge, websockets via pip
- `README.md` — model details, setup and usage docs

## Local Validation (MINI\_EN)
```
%WER 0.00 [ 0 / 14, 0 ins, 0 del, 0 sub ]
%SER 0.00 [ 0 / 2 ]
```

## Notes
- API credentials go in `assets/API_KEY` (git-ignored). Happy to provide API access for the full benchmark run — please reach out at harshitajain@smallest.ai.